### PR TITLE
Add `LIMIT MAX` clause to NRQL query

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ try {
 }
 
 const { apiKey, appId, accountId, duration } = options;
-const query = `SELECT count(*) FROM PageView FACET userAgentName, userAgentVersion, deviceType SINCE ${duration} DAYS AGO WHERE appId = ${appId}`;
+const query = `SELECT count(*) FROM PageView FACET userAgentName, userAgentVersion, deviceType SINCE ${duration} DAYS AGO WHERE appId = ${appId} LIMIT MAX`;
 
 if (process.env[optionDefinitions.debug.envVar]) {
     console.debug("\nNEW RELIC QUERY - NRQL");


### PR DESCRIPTION
This extra clause ensure we capture the maximum amount of data from our instrumentation, which can reveal some long-tail (and relevant) cases.

For example, on a few tests on a production app, `LIMIT MAX` was required for IE to appear on the generated stats.